### PR TITLE
Fix contact

### DIFF
--- a/app/views/opendata/agents/pages/app/app/index.html.erb
+++ b/app/views/opendata/agents/pages/app/app/index.html.erb
@@ -94,7 +94,7 @@ categories = [
         </dd>
       <% elsif @cur_page.contact_group %>
         <dt><%= @cur_page.t :user_id %></dt>
-        <dd><%= @cur_page.contact_group.full_name %><br /></dd>
+        <dd><%= @@cur_page.contact_group.name.sub(/.*\//, "") %><br /></dd>
       <% elsif @cur_page.groups.present? %>
         <dt><%= @cur_page.t :user_id %></dt>
         <dd><%= @cur_page.groups.first.name %><br /></dd>

--- a/app/views/opendata/agents/pages/app/app/index.html.erb
+++ b/app/views/opendata/agents/pages/app/app/index.html.erb
@@ -94,7 +94,7 @@ categories = [
         </dd>
       <% elsif @cur_page.contact_group %>
         <dt><%= @cur_page.t :user_id %></dt>
-        <dd><%= @@cur_page.contact_group.name.sub(/.*\//, "") %><br /></dd>
+        <dd><%= @cur_page.contact_group.name.sub(/.*\//, "") %><br /></dd>
       <% elsif @cur_page.groups.present? %>
         <dt><%= @cur_page.t :user_id %></dt>
         <dd><%= @cur_page.groups.first.name %><br /></dd>

--- a/app/views/opendata/agents/pages/dataset/dataset/index.html.erb
+++ b/app/views/opendata/agents/pages/dataset/dataset/index.html.erb
@@ -162,7 +162,7 @@ categories = [
             </dd>
           <% elsif @cur_page.contact_group %>
             <dt><%= @cur_page.t :user_id %></dt>
-            <dd><%= @cur_page.contact_group.full_name %><br /></dd>
+            <dd><%= @cur_page.contact_group.name.sub(/.*\//, "") %><br /></dd>
           <% elsif @cur_page.groups.present? %>
             <dt><%= @cur_page.t :user_id %></dt>
             <dd><%= @cur_page.groups.first.name %><br /></dd>

--- a/app/views/opendata/agents/pages/idea/idea/index.html.erb
+++ b/app/views/opendata/agents/pages/idea/idea/index.html.erb
@@ -126,7 +126,7 @@ categories = [
         </dd>
       <% elsif @cur_page.contact_group %>
         <dt><%= @cur_page.t :user_id %></dt>
-        <dd><%= @cur_page.contact_group.full_name %><br /></dd>
+        <dd><%= @@cur_page.contact_group.name.sub(/.*\//, "") %><br /></dd>
       <% elsif @cur_page.groups.present? %>
         <dt><%= @cur_page.t :user_id %></dt>
         <dd><%= @cur_page.groups.first.name %><br /></dd>

--- a/app/views/opendata/agents/pages/idea/idea/index.html.erb
+++ b/app/views/opendata/agents/pages/idea/idea/index.html.erb
@@ -126,7 +126,7 @@ categories = [
         </dd>
       <% elsif @cur_page.contact_group %>
         <dt><%= @cur_page.t :user_id %></dt>
-        <dd><%= @@cur_page.contact_group.name.sub(/.*\//, "") %><br /></dd>
+        <dd><%= @cur_page.contact_group.name.sub(/.*\//, "") %><br /></dd>
       <% elsif @cur_page.groups.present? %>
         <dt><%= @cur_page.t :user_id %></dt>
         <dd><%= @cur_page.groups.first.name %><br /></dd>


### PR DESCRIPTION
作成者のグループ表示の仕様変更
「グループの/をスペースに置換して表示する」から「グループの最下層の名称を表示する」に変更
