### PR TITLE
[add] ckan dataset list parts

### DIFF
--- a/app/controllers/ckan/agents/parts/page_controller.rb
+++ b/app/controllers/ckan/agents/parts/page_controller.rb
@@ -1,0 +1,7 @@
+class Ckan::Agents::Parts::PageController < ApplicationController
+  include Cms::PartFilter::View
+
+  def index
+    @cur_node = @cur_part.parent.becomes_with_route
+  end
+end

--- a/app/models/ckan/initializer.rb
+++ b/app/models/ckan/initializer.rb
@@ -2,5 +2,6 @@ module Ckan
   class Initializer
     Cms::Node.plugin "ckan/page"
     Cms::Part.plugin "ckan/status"
+    Cms::Part.plugin "ckan/page"
   end
 end

--- a/app/models/ckan/part.rb
+++ b/app/models/ckan/part.rb
@@ -8,4 +8,13 @@ module Ckan::Part
 
     default_scope ->{ where(route: "ckan/status") }
   end
+
+  class Page
+    include Cms::Model::Part
+    include Cms::Addon::Release
+    include Cms::Addon::GroupPermission
+    include History::Addon::Backup
+
+    default_scope ->{ where(route: "ckan/page") }
+  end
 end

--- a/app/views/ckan/agents/parts/page/index.erb
+++ b/app/views/ckan/agents/parts/page/index.erb
@@ -1,0 +1,1 @@
+<%= render file: 'ckan/agents/nodes/page/index.html.erb' %>

--- a/config/locales/ckan/ja.yml
+++ b/config/locales/ckan/ja.yml
@@ -12,6 +12,7 @@ ja:
       ckan/page: 新着
     parts:
       ckan/status: 件数
+      ckan/page: ページリスト
 
   modules:
     ckan: CKAN

--- a/config/routes/ckan/routes.rb
+++ b/config/routes/ckan/routes.rb
@@ -17,5 +17,6 @@ SS::Application.routes.draw do
 
   part "ckan" do
     get "status" => "public#index", cell: "parts/status"
+    get "page" => "public#index", cell: "parts/page"
   end
 end


### PR DESCRIPTION
事前の打ち合わせでは標準機能のページリストパーツで対応するということでしたが、
ページリストパーツというのは cms_pages の一覧を表示する機能を持っています。

今回の ckan データセットノードは、cms_pages にドキュメントを作成しません。
ckan データセットノードは、RSS ノードのように外部データを取り込み cms_pages にドキュメントを追加しませんので、標準機能のページリストパーツはうまく動作しません。

新着一覧を表示するパーツを別に開発する必要が出てきましたので開発しました。

補足

取り込む場合のメリット・取り込まない場合のメリット、それぞれあります。

取り込まない場合の最大のメリットとして、ckan 側のデータを削除すれば、それが即座に反映される点にあると考えています。
取り込んだ場合、ckan 側のデータを削除しても即座に反映されず、再取り込みなどの運用の手間が増えます。
今回は、削除が即反映されるという点を評価し、現行の仕様のままとしたいと思います。
