### PR TITLE
Ckan node html

### DIFF
--- a/app/controllers/ckan/agents/nodes/page_controller.rb
+++ b/app/controllers/ckan/agents/nodes/page_controller.rb
@@ -1,3 +1,26 @@
 class Ckan::Agents::Nodes::PageController < ApplicationController
   include Cms::NodeFilter::View
+
+  def rss
+    rss = RSS::Maker.make("2.0") do |rss|
+      rss.channel.title       = "#{@cur_node.name} - #{@cur_node.site.name}"
+      rss.channel.link        = @cur_node.full_url
+      rss.channel.description = "CKAN News"
+      rss.channel.about       = @cur_node.full_url
+      rss.channel.language    = "ja"
+
+      @cur_node.values.each do |value|
+        date = value['metadata_modified']
+        rss.items.new_item do |entry|
+          entry.title       = value['name']
+          entry.link        = root_url # TODO: Fix me
+                                       # NOTE: `value['url']` doesn't exist
+          entry.description = nil
+          entry.pubDate     = date.to_s
+        end
+      end
+    end
+
+    render xml: rss.to_xml, content_type: "application/rss+xml"
+  end
 end

--- a/app/models/ckan/node.rb
+++ b/app/models/ckan/node.rb
@@ -3,8 +3,8 @@ module Ckan::Node
     include Cms::Model::Node
     include Cms::Addon::NodeSetting
     include Cms::Addon::Meta
-    include Ckan::Addon::Server
     include Cms::Addon::PageList
+    include Ckan::Addon::Server
     include Cms::Addon::Release
     include Cms::Addon::GroupPermission
     include History::Addon::Backup

--- a/app/models/concerns/ckan/addon/server.rb
+++ b/app/models/concerns/ckan/addon/server.rb
@@ -32,5 +32,49 @@ module Ckan::Addon
           end
         end
       end
+
+      def render_loop_html(value, html: nil)
+        (html || loop_html).gsub(/\#\{(.*?)\}/) do |m|
+          str = template_variable_get(value, $1) rescue false
+          str == false ? m : str
+        end
+      end
+
+      def template_variable_get(value, name)
+        if name == "name"
+          value['name']
+        elsif name == "url"
+          self.try(:url) # TODO: Fix me
+        elsif name == "summary"
+          value['notes']
+        elsif name == "class"
+          value['name']
+        elsif name == "new"
+          in_new_days?(Time.zone.parse(value['metadata_modified']).to_date) ? "new" : nil
+        elsif name == "created_date"
+          I18n.l Time.zone.parse(value['metadata_created']).to_date
+        elsif name =~ /\Acreated_date\.(\w+)\z/
+          I18n.l Time.zone.parse(value['metadata_created']).to_date, format: $1.to_sym
+        elsif name == "updated_date"
+          I18n.l Time.zone.parse(value['metadata_modified']).to_date
+        elsif name =~ /\Aupdated_date\.(\w+)\z/
+          I18n.l Time.zone.parse(value['metadata_modified']).to_date, format: $1.to_sym
+        elsif name == "created_time"
+          I18n.l Time.zone.parse(value['metadata_created'])
+        elsif name =~ /\Acreated_time\.(\w+)\z/
+          I18n.l Time.zone.parse(value['metadata_created']), format: $1.to_sym
+        elsif name == "updated_time"
+          I18n.l Time.zone.parse(value['metadata_modified'])
+        elsif name =~ /\Aupdated_time\.(\w+)\z/
+          I18n.l Time.zone.parse(value['metadata_modified']), format: $1.to_sym
+        elsif name == "group"
+          group = value['groups'].first
+          group ? group['display_name'] : ""
+        elsif name == "groups"
+          value['groups'].map { |g| g['display_name'] }.join(", ")
+        else
+          false
+        end
+      end
   end
 end

--- a/app/views/ckan/agents/nodes/page/index.html.erb
+++ b/app/views/ckan/agents/nodes/page/index.html.erb
@@ -1,19 +1,21 @@
 <div class="ckan-pages pages">
 <%= @cur_node.upper_html.html_safe if @cur_node.upper_html.present? %>
+<% if @cur_node.loop_html.present? %>
+  <% loop_html = @cur_node.loop_html %>
+<% else %>
+  <%
+    loop_html = <<EOS
+<article class="item-\#{class} \#{new}">
+  <header>
+    <time datetime="\#{updated_date.iso}">\#{updated_date.long}</time>
+    <h2><a href="\#{url}">\#{name}</a></h2>
+  </header>
+</article>
+EOS
+  %>
+<% end %>
 <% @cur_node.values.each do |e| %>
-  <% modified = Time.zone.parse(e['metadata_modified']).to_date %>
-  <%# def in_new_days?(date) %>
-  <%#   date + new_days > (@cur_date || Time.zone.now) %>
-  <%# end %>
-  <%# # NOTE: `@cur_date` is `nil` always. %>
-  <%# in_new_days = (modified + @cur_node.new_days > (@cur_date || Time.zone.now)) %>
-  <% in_new_days = (modified + @cur_node.new_days > Time.zone.now) %>
-  <article class="item-<%= e['name'] %> <%= in_new_days ? 'new' : nil %>">
-    <header>
-      <time datetime="<%= I18n.l modified, format: :iso %>"><%= I18n.l modified, format: :long %></time>
-      <h2><%= link_to e['title'], root_url %></h2>
-    </header>
-  </article>
+<%= @cur_node.render_loop_html(e, html: loop_html).html_safe %>
 <% end %>
 <%= @cur_node.lower_html.html_safe if @cur_node.lower_html.present? %>
 </div>

--- a/app/views/ckan/agents/nodes/page/index.html.erb
+++ b/app/views/ckan/agents/nodes/page/index.html.erb
@@ -1,9 +1,17 @@
-<ul>
+<div class="ckan-pages pages">
 <% @cur_node.values.each do |e| %>
-  <li>
-    <span><%= e['metadata_created'] %></span>
-    <span><%= e['metadata_modified'] %></span>
-    <span><%= e['name'] %></span>
-  </li>
+  <% modified = Time.zone.parse(e['metadata_modified']).to_date %>
+  <%# def in_new_days?(date) %>
+  <%#   date + new_days > (@cur_date || Time.zone.now) %>
+  <%# end %>
+  <%# # NOTE: `@cur_date` is `nil` always. %>
+  <%# in_new_days = (modified + @cur_node.new_days > (@cur_date || Time.zone.now)) %>
+  <% in_new_days = (modified + @cur_node.new_days > Time.zone.now) %>
+  <article class="item-<%= e['name'] %> <%= in_new_days ? 'new' : nil %>">
+    <header>
+      <time datetime="<%= I18n.l modified, format: :iso %>"><%= I18n.l modified, format: :long %></time>
+      <h2><%= link_to e['title'], root_url %></h2>
+    </header>
+  </article>
 <% end %>
-</ul>
+</div>

--- a/app/views/ckan/agents/nodes/page/index.html.erb
+++ b/app/views/ckan/agents/nodes/page/index.html.erb
@@ -1,4 +1,5 @@
 <div class="ckan-pages pages">
+<%= @cur_node.upper_html.html_safe if @cur_node.upper_html.present? %>
 <% @cur_node.values.each do |e| %>
   <% modified = Time.zone.parse(e['metadata_modified']).to_date %>
   <%# def in_new_days?(date) %>
@@ -14,4 +15,5 @@
     </header>
   </article>
 <% end %>
+<%= @cur_node.lower_html.html_safe if @cur_node.lower_html.present? %>
 </div>

--- a/config/routes/ckan/routes.rb
+++ b/config/routes/ckan/routes.rb
@@ -13,6 +13,7 @@ SS::Application.routes.draw do
 
   node "ckan" do
     get "page/(index.:format)" => "public#index", cell: "nodes/page"
+    get "page/rss" => "public#rss", cell: "nodes/page"
   end
 
   part "ckan" do


### PR DESCRIPTION
上部，下部，ループHTMLを設定可能にしました．

まず初期化後，

``` ruby
Ckan::Node::Page.create(
  site: SS::Site.find_by(host: 'www'),
  ckan_url: 'http://demo.ckan.org', ckan_max_docs: 10,
  name: 'CKAN Node 1',
  filename: 'ckannode1'
)
```

でノードを作成します．この状態で http://localhost:3000/ckannode1/ を確認すると，デフォルトのループHTML

``` html
<article class="item-#{class} #{new}">
  <header>
    <time datetime="#{updated_date.iso}">#{updated_date.long}</time>
    <h2><a href="#{url}">#{name}</a></h2>
  </header>
</article>
```

での描画が確認出来ます．

![default-html](https://cloud.githubusercontent.com/assets/1495128/12578784/7be5b45a-c466-11e5-8f45-2ff9b4333b4e.png)

次にrails consoleで以下のコードを実行して上部，下部，ループHTMLに独自のものを設定します．

``` ruby
loop_html = <<EOS
<ul>
<li>name: \#{name}</li>
<li>url: \#{url}</li>
<li>summary: \#{summary}</li>
<li>class: \#{class}</li>
<li>new: \#{new}</li>
<li>created_date: \#{created_date}</li>
<li>created_date.iso: \#{created_date.iso}</li>
<li>created_date.long: \#{created_date.long}</li>
<li>updated_date: \#{updated_date}</li>
<li>updated_date.iso: \#{updated_date.iso}</li>
<li>updated_date.long: \#{updated_date.long}</li>
<li>created_time: \#{created_time}</li>
<li>created_time.iso: \#{created_time.iso}</li>
<li>created_time.long: \#{created_time.long}</li>
<li>updated_time: \#{updated_time}</li>
<li>updated_time.iso: \#{updated_time.iso}</li>
<li>updated_time.long: \#{updated_time.long}</li>
<li>group: \#{group}</li>
<li>groups: \#{groups}</li>
</ul>
EOS

upper_html = <<EOS
<div class="upper-lower-html">
  <span>upper HTML</span>
EOS

lower_html = <<EOS
  <span>lower HTML</span>
</div><!-- upper-lower-html end -->
EOS

Ckan::Node::Page.find_by(filename: 'ckannode1').update(
  loop_html: loop_html, upper_html: upper_html, lower_html: lower_html
)
```

先ほどのページが指定したHTMLで描画されていることが確認出来ます．

![my-html](https://cloud.githubusercontent.com/assets/1495128/12578787/81df7d32-c466-11e5-855a-493b7347172d.png)

テンプレート内の表記と，JSONのフィールドと処理の対応は以下の通りになります．

| テンプレート内表記 | JSON内フィールドと処理 |
| --- | --- |
| name | name |
| url | ※`@cur_node.url`を臨時で表示 |
| summary | notes |
| class | name |
| new | metadata_modified (が`new_days`以内かどうかの結果) |
| created_date | metadata_created の日付 |
| created_date.iso | metadata_created の日付 (ISO) |
| created_date.long | metadata_created の日付 (YYYY年M月D日) |
| updated_date | metadata_modified の日付 |
| updated_date.iso | metadata_modified の日付 (ISO) |
| updated_date.long | metadata_modified の日付 (YYYY年M月D日) |
| created_time | metadata_created の日時 |
| created_time.iso | metadata_created の日時 (ISO) |
| created_time.long | metadata_created の日時 (YYYY年M月D日) |
| updated_time | metadata_modified の日時 |
| updated_time.iso | metadata_modified の日時 (ISO) |
| updated_time.long | metadata_modified の日時 (YYYY年M月D日) |
| group | groups の0番目の display_name |
| groups | groups の全ての display_name を , でつなげる |
