### PR TITLE
[add] "organization" to Ckan::Part::Status ckan_status column

### DIFF
--- a/app/models/concerns/ckan/addon/status.rb
+++ b/app/models/concerns/ckan/addon/status.rb
@@ -16,7 +16,7 @@ module Ckan::Addon
       before_validation :set_ckan_basicauth_password, if: ->{ in_ckan_basicauth_password.present? }
       validates :ckan_url, format: /\Ahttps?:\/\//
       validates :ckan_basicauth_state, inclusion: { in: %w(enabled disabled) }
-      validates :ckan_status, inclusion: { in: %w(dataset tag group related_item) }
+      validates :ckan_status, inclusion: { in: %w(dataset tag group related_item organization) }
     end
 
     private
@@ -26,7 +26,7 @@ module Ckan::Addon
 
     public
       def ckan_status_options
-        %w(dataset tag group related_item).map { |m| [ I18n.t("ckan.options.ckan_status.#{m}"), m ] }.to_a
+        %w(dataset tag group related_item organization).map { |m| [ I18n.t("ckan.options.ckan_status.#{m}"), m ] }.to_a
       end
 
       def ckan_basicauth_state_options
@@ -65,7 +65,8 @@ module Ckan::Addon
           'dataset' => 'package_list',
           'tag' => 'tag_list',
           'group' => 'group_list',
-          'related_item' => 'related_list'
+          'related_item' => 'related_list',
+          'organization' => 'organization_list'
         }[ckan_status]
       end
   end

--- a/config/locales/ckan/ja.yml
+++ b/config/locales/ckan/ja.yml
@@ -6,6 +6,7 @@ ja:
         tag: タグ
         group: グループ
         related_item: 関連アイテム
+        organization: 組織
       ckan_basicauth_state:
         enabled: 有効
         disabled: 無効
@@ -51,6 +52,7 @@ ja:
         - タグ： tag_list
         - グループ： group_list
         - 関連アイテム： related_list
+        - 組織： organization_list
     ckan/addon/server:
       ckan_url:
         - URLの可変部分を設定します。


### PR DESCRIPTION
`"organization"` を `Ckan::Part::Status` の `ckan_status` カラムに選択出来るようにします．
## 確認方法

DBを初期化．

``` sh
bundle exec rake db:drop
bundle exec rake db:create_indexes
bundle exec rake ss:create_user data='{ name: "システム管理者", email: "sys@example.jp", password: "pass" }'
bundle exec rake ss:create_site data='{ name: "サイト名", host: "www", domains: "localhost:3000" }'
bundle exec rake db:seed name=users site=www
bundle exec rake db:seed name=opendata site=www
```

`rails c`上で以下を実行．

``` ruby
Ckan::Part::Status.create(
  site: SS::Site.find_by(host: 'www'),
  ckan_url: 'http://demo.ckan.org', ckan_status: 'organization',
  ckan_basicauth_state: 'disabled',
  name: 'CKAN Part 5',
  filename: 'ckanpart5.part.html'
)
```

ブラウザで`http://localhost:3000/ckanpart5.part.html`を開く．

CKAN API の `"http://demo.ckan.org/api/3/action/organization_list"` を起動します．JSONのresult の配列のサイズを返します．
