### PR TITLE
[add] ckan_value_url column to Ckan::Addon::Status module

### DIFF
--- a/app/models/concerns/ckan/addon/status.rb
+++ b/app/models/concerns/ckan/addon/status.rb
@@ -9,9 +9,10 @@ module Ckan::Addon
       field :ckan_basicauth_username, type: String
       field :ckan_basicauth_password, type: String
       field :ckan_status, type: String
+      field :ckan_value_url, type: String
       attr_accessor :in_ckan_basicauth_password
       permit_params :ckan_url, :ckan_basicauth_state, :ckan_basicauth_username, :in_ckan_basicauth_password
-      permit_params :ckan_status
+      permit_params :ckan_status, :ckan_value_url
 
       before_validation :set_ckan_basicauth_password, if: ->{ in_ckan_basicauth_password.present? }
       validates :ckan_url, format: /\Ahttps?:\/\//

--- a/app/views/ckan/agents/addons/status/_form.html.erb
+++ b/app/views/ckan/agents/addons/status/_form.html.erb
@@ -13,4 +13,7 @@
 
   <dt><%= @model.t :ckan_status %><%= @model.tt :ckan_status %></dt>
   <dd><%= f.select :ckan_status, @item.ckan_status_options  %></dd>
+
+  <dt><%= @model.t :ckan_value_url %><%= @model.tt :ckan_value_url %></dt>
+  <dd><%= f.text_field :ckan_value_url, class: "ckan-value-url" %></dt>
 </dl>

--- a/app/views/ckan/agents/addons/status/_show.html.erb
+++ b/app/views/ckan/agents/addons/status/_show.html.erb
@@ -10,4 +10,7 @@
 
   <dt><%= @model.t :ckan_status %></dt>
   <dd><%= @item.label :ckan_status %></dd>
+
+  <dt><%= @model.t :ckan_value_url %></dt>
+  <dd><%= @item.ckan_value_url %>
 </dl>

--- a/app/views/ckan/agents/parts/status/index.erb
+++ b/app/views/ckan/agents/parts/status/index.erb
@@ -1,4 +1,8 @@
 <div class="<%= @cur_part.ckan_status %>">
+  <% if @cur_part.ckan_value_url.present? %>
+  <span><%= link_to @cur_part.value, @cur_part.ckan_value_url %></span>
+  <% else %>
   <span><%= @cur_part.value %></span>
+  <% end %>
   <span><%= @cur_part.label :ckan_status %></span>
 </div>

--- a/config/locales/ckan/ja.yml
+++ b/config/locales/ckan/ja.yml
@@ -38,6 +38,7 @@ ja:
         ckan_basicauth_username: Basic認証ユーザー名
         ckan_basicauth_password: Basic認証パスワード
         ckan_status: 種類
+        ckan_value_url: 件数部分のリンクURL
 
   tooltip:
     ckan/addon/status:
@@ -53,6 +54,8 @@ ja:
         - グループ： group_list
         - 関連アイテム： related_list
         - 組織： organization_list
+      ckan_value_url:
+        - URLを設定しておくと件数部分がそのリンクに変わります。
     ckan/addon/server:
       ckan_url:
         - URLの可変部分を設定します。


### PR DESCRIPTION
`Ckan::Addon::Status`に`ckan_value_url`カラムを追加する．

このカラムが `.present?` について真であれば，パーツの件数部分がリンクに変わる．
## 確認方法
#117 の状態から再開(DB初期化して`ckanpart5.part.html`が出来ている状態)．

`rails c`上で以下を実行．

``` ruby
Ckan::Part::Status.create(
  site: SS::Site.find_by(host: 'www'),
  ckan_url: 'http://demo.ckan.org', ckan_status: 'organization',
  ckan_basicauth_state: 'disabled', ckan_value_url: 'http://demo.ss-proj.org',
  name: 'CKAN Part 6',
  filename: 'ckanpart6.part.html'
)
```

ブラウザで`http://localhost:3000/ckanpart6.part.html`を開く．

件数部分がリンクになっている．

一方で `http://localhost:3000/ckanpart5.part.html` の方はリンクにはなっていない (`ckan_value_url` が空っぽなので)．
